### PR TITLE
Add support for SpotBugs native XML format (spotbugsXml.xml)

### DIFF
--- a/input/findbugs.go
+++ b/input/findbugs.go
@@ -13,6 +13,7 @@ func init() {
 }
 
 func convertFindBugs(content []byte) *output.Result {
+	// xdoc format: BugInstance nested inside <file classname="..."> elements
 	type BugInstance struct {
 		Type       string `xml:"type,attr"`
 		Priority   string `xml:"priority,attr"`
@@ -29,14 +30,39 @@ func convertFindBugs(content []byte) *output.Result {
 	type SrcDir struct {
 		Path string `xml:",cdata"`
 	}
+
 	type Project struct {
 		SrcDirs []SrcDir `xml:"SrcDir"`
 	}
 
+	// native format: BugInstance is a direct child of BugCollection with nested SourceLine
+	type NativeSourceLine struct {
+		Sourcepath string `xml:"sourcepath,attr"`
+		Start      int    `xml:"start,attr"`
+		Synthetic  string `xml:"synthetic,attr"`
+	}
+
+	type NativeBugInstance struct {
+		Type        string             `xml:"type,attr"`
+		Priority    string             `xml:"priority,attr"`
+		LongMessage string             `xml:"LongMessage"`
+		SourceLines []NativeSourceLine `xml:"SourceLine"`
+	}
+
+	// nativeBug holds a parsed bug entry from the native format before grouping by file
+	type nativeBug struct {
+		filePath string
+		bugType  string
+		severity string
+		message  string
+		line     int
+	}
+
 	type BugCollection struct {
-		XMLName xml.Name `xml:"BugCollection"`
-		Files   []File   `xml:"file"`
-		Project Project  `xml:"Project"`
+		XMLName    xml.Name           `xml:"BugCollection"`
+		Files      []File             `xml:"file"`
+		NativeBugs []NativeBugInstance `xml:"BugInstance"`
+		Project    Project            `xml:"Project"`
 	}
 
 	var bc BugCollection
@@ -48,18 +74,68 @@ func convertFindBugs(content []byte) *output.Result {
 	}
 
 	result := output.Result{}
-	for _, file := range bc.Files {
-		// com.example.MyClass$InnerClass -> com/example/MyClass.java
-		className := file.ClassName
-		if idx := strings.Index(className, "$"); idx != -1 {
-			className = className[:idx]
+
+	if len(bc.Files) > 0 {
+		// xdoc format
+		for _, file := range bc.Files {
+			// com.example.MyClass$InnerClass -> com/example/MyClass.java
+			className := file.ClassName
+			if idx := strings.Index(className, "$"); idx != -1 {
+				className = className[:idx]
+			}
+			filePath := path.Join(srcDir, strings.ReplaceAll(className, ".", "/")+".java")
+			f := result.AddFile(filePath)
+			for _, bi := range file.BugInstances {
+				f.AddError(bi.Type, severityFindBugs(bi.Priority), bi.Message, bi.LineNumber)
+			}
 		}
-		filePath := path.Join(srcDir, strings.ReplaceAll(className, ".", "/")+".java")
-		f := result.AddFile(filePath)
-		for _, bi := range file.BugInstances {
-			f.AddError(bi.Type, severityFindBugs(bi.Priority), bi.Message, bi.LineNumber)
+		return &result
+	}
+
+	// native format: collect bugs then group by file path to produce one ResultFile per source file
+	var bugs []nativeBug
+	for _, bi := range bc.NativeBugs {
+		sourcepath, start := "", 0
+		for _, sl := range bi.SourceLines {
+			if sl.Synthetic == "true" {
+				sourcepath = sl.Sourcepath
+				start = sl.Start
+				break
+			}
+		}
+		if sourcepath == "" && len(bi.SourceLines) > 0 {
+			sourcepath = bi.SourceLines[0].Sourcepath
+			start = bi.SourceLines[0].Start
+		}
+		if sourcepath == "" {
+			continue
+		}
+		bugs = append(bugs, nativeBug{
+			filePath: path.Join(srcDir, sourcepath),
+			bugType:  bi.Type,
+			severity: severityFindBugsNative(bi.Priority),
+			message:  bi.LongMessage,
+			line:     start,
+		})
+	}
+
+	seen := map[string]bool{}
+	var filePaths []string
+	for _, b := range bugs {
+		if !seen[b.filePath] {
+			seen[b.filePath] = true
+			filePaths = append(filePaths, b.filePath)
 		}
 	}
+	for _, fp := range filePaths {
+		f := result.AddFile(fp)
+		for _, b := range bugs {
+			if b.filePath == fp {
+				f.AddError(b.bugType, b.severity, b.message, b.line)
+			}
+		}
+	}
+
 	return &result
 }
 
@@ -71,6 +147,17 @@ func severityFindBugs(priority string) string {
 		return "warning"
 	case "Low":
 		return "info"
+	default:
+		return "info"
+	}
+}
+
+func severityFindBugsNative(priority string) string {
+	switch priority {
+	case "1":
+		return "error"
+	case "2":
+		return "warning"
 	default:
 		return "info"
 	}

--- a/input/findbugs_test.go
+++ b/input/findbugs_test.go
@@ -89,3 +89,63 @@ func TestConvertFindBugs_Priority(t *testing.T) {
 		}
 	}
 }
+
+func TestConvertFindBugs_NativeFormat(t *testing.T) {
+	xml := []byte(`<?xml version="1.0" encoding="utf-8"?>
+<BugCollection>
+  <Project>
+    <SrcDir>/src/main/java</SrcDir>
+  </Project>
+  <BugInstance type='HE_EQUALS_USE_HASHCODE' priority='1'>
+    <LongMessage>example.App defines equals and uses Object.hashCode()</LongMessage>
+    <Class classname='example.App' primary='true'>
+      <SourceLine classname='example.App' start='12' end='58' sourcepath='example/App.java'/>
+    </Class>
+    <Method primary='true' name='equals'>
+      <SourceLine start='19' end='22' sourcepath='example/App.java'/>
+    </Method>
+    <SourceLine synthetic='true' start='19' end='22' sourcepath='example/App.java'/>
+  </BugInstance>
+</BugCollection>`)
+
+	r := convertFindBugs(xml)
+
+	if len(r.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(r.Files))
+	}
+	if r.Files[0].Name != "/src/main/java/example/App.java" {
+		t.Errorf("unexpected file name: %s", r.Files[0].Name)
+	}
+	if len(r.Files[0].Errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(r.Files[0].Errors))
+	}
+	e := r.Files[0].Errors[0]
+	if e.Source != "HE_EQUALS_USE_HASHCODE" {
+		t.Errorf("expected source HE_EQUALS_USE_HASHCODE, got %s", e.Source)
+	}
+	if e.Severity != "error" {
+		t.Errorf("expected severity error, got %s", e.Severity)
+	}
+	if e.Line != 19 {
+		t.Errorf("expected line 19, got %d", e.Line)
+	}
+}
+
+func TestConvertFindBugs_NativePriority(t *testing.T) {
+	cases := []struct {
+		priority string
+		want     string
+	}{
+		{"1", "error"},
+		{"2", "warning"},
+		{"3", "info"},
+		{"5", "info"},
+	}
+
+	for _, tc := range cases {
+		got := severityFindBugsNative(tc.priority)
+		if got != tc.want {
+			t.Errorf("native priority %q: expected %q, got %q", tc.priority, tc.want, got)
+		}
+	}
+}

--- a/scarfco_test.go
+++ b/scarfco_test.go
@@ -111,6 +111,34 @@ func TestIntegration_CPD(t *testing.T) {
 	}
 }
 
+func TestIntegration_SpotbugsXml(t *testing.T) {
+	content := readTestdata(t, "spotbugsXml.xml")
+	r, err := input.Convert(content)
+	if err != nil {
+		t.Fatalf("Convert error: %v", err)
+	}
+
+	if len(r.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(r.Files))
+	}
+	if !strings.HasSuffix(r.Files[0].Name, "example/App.java") {
+		t.Errorf("unexpected file name: %s", r.Files[0].Name)
+	}
+	if len(r.Files[0].Errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(r.Files[0].Errors))
+	}
+	e := r.Files[0].Errors[0]
+	if e.Source != "HE_EQUALS_USE_HASHCODE" {
+		t.Errorf("expected source HE_EQUALS_USE_HASHCODE, got %q", e.Source)
+	}
+	if e.Severity != "error" {
+		t.Errorf("expected severity error, got %q", e.Severity)
+	}
+	if e.Line != 19 {
+		t.Errorf("expected line 19, got %d", e.Line)
+	}
+}
+
 func TestIntegration_Checkstyle(t *testing.T) {
 	content := readTestdata(t, "checkstyle-result.xml")
 	r, err := input.Convert(content)


### PR DESCRIPTION
The existing parser only handled the xdoc/Maven site report format where BugInstance elements are nested inside <file> elements. This extends convertFindBugs to also parse the native SpotBugs XML format where BugInstance elements are direct children of BugCollection with SourceLine child elements providing file path and line number information.