### PR TITLE
Convert SARIF artifact URIs to relative paths from working directory

### DIFF
--- a/output/result.go
+++ b/output/result.go
@@ -5,6 +5,7 @@ import "errors"
 type Result struct {
 	Tool    string
 	ToolURI string
+	BaseDir string
 	Files   []ResultFile
 }
 

--- a/output/sarif.go
+++ b/output/sarif.go
@@ -1,6 +1,10 @@
 package output
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+)
 
 type sarifOutput struct {
 	Schema  string    `json:"$schema"`
@@ -75,6 +79,12 @@ func toSARIF(r *Result) string {
 
 	results := []sarifResult{}
 	for _, f := range r.Files {
+		uri := f.Name
+		if r.BaseDir != "" {
+			if rel, err := filepath.Rel(r.BaseDir, f.Name); err == nil && !strings.HasPrefix(rel, "..") {
+				uri = rel
+			}
+		}
 		for _, e := range f.Errors {
 			results = append(results, sarifResult{
 				RuleID:  e.Source,
@@ -83,7 +93,7 @@ func toSARIF(r *Result) string {
 				Locations: []sarifLocation{
 					{
 						PhysicalLocation: sarifPhysicalLocation{
-							ArtifactLocation: sarifArtifactLocation{URI: f.Name},
+							ArtifactLocation: sarifArtifactLocation{URI: uri},
 							Region:           sarifRegion{StartLine: e.Line},
 						},
 					},

--- a/output/sarif_test.go
+++ b/output/sarif_test.go
@@ -124,6 +124,42 @@ func TestToSARIF_ToolNameFallback(t *testing.T) {
 	}
 }
 
+func TestToSARIF_RelativePath(t *testing.T) {
+	r := &Result{BaseDir: "/repo"}
+	f := r.AddFile("/repo/src/Foo.java")
+	f.AddError("Rule", "error", "msg", 1)
+
+	got := toSARIF(r)
+
+	if !strings.Contains(got, `"uri": "src/Foo.java"`) {
+		t.Errorf("expected relative path, got:\n%s", got)
+	}
+}
+
+func TestToSARIF_AbsPathFallback(t *testing.T) {
+	r := &Result{BaseDir: "/repo"}
+	f := r.AddFile("/other/src/Foo.java")
+	f.AddError("Rule", "error", "msg", 1)
+
+	got := toSARIF(r)
+
+	if !strings.Contains(got, `"uri": "/other/src/Foo.java"`) {
+		t.Errorf("expected absolute path for file outside BaseDir, got:\n%s", got)
+	}
+}
+
+func TestToSARIF_NoBBaseDir(t *testing.T) {
+	r := &Result{}
+	f := r.AddFile("/abs/path/Foo.java")
+	f.AddError("Rule", "error", "msg", 1)
+
+	got := toSARIF(r)
+
+	if !strings.Contains(got, `"uri": "/abs/path/Foo.java"`) {
+		t.Errorf("expected original absolute path when no BaseDir, got:\n%s", got)
+	}
+}
+
 func TestConvert_SARIF(t *testing.T) {
 	r := &Result{}
 	f := r.AddFile("/src/A.java")

--- a/scarfco.go
+++ b/scarfco.go
@@ -27,6 +27,9 @@ func run(format string) error {
 		return err
 	}
 	if result != nil {
+		if cwd, err := os.Getwd(); err == nil {
+			result.BaseDir = cwd
+		}
 		converted, err := output.Convert(result, format)
 		if err != nil {
 			return err


### PR DESCRIPTION
SARIF 2.1.0 spec and GitHub Code Scanning recommend relative paths in artifactLocation.uri. Absolute paths outside the base directory are kept as-is.